### PR TITLE
Refactor benchmark CLI to use Typer and Rich

### DIFF
--- a/jaxrl/cli.py
+++ b/jaxrl/cli.py
@@ -4,6 +4,7 @@ import jax
 from jaxrl.experiment import Experiment
 from jaxrl.play import play_from_config, play_from_run
 from jaxrl.train import train_run
+from jaxrl.benchmark import main as benchmark_main
 import shutil
 
 
@@ -57,6 +58,9 @@ def clean():
 
         if checkpoint_count == 0:
             shutil.rmtree(folder)
+
+
+app.command("benchmark")(benchmark_main)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- migrate benchmark script to a Typer-based CLI and enrich output with Rich
- allow overriding rollout steps and display results using a rich console
- expose benchmarking as a new `benchmark` command in the main CLI

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jax')*
- `pip install jax==0.6.0` *(fails: Could not find a version that satisfies the requirement jax==0.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bedca60fcc8331bf7d6dfe23d4bd7b