### PR TITLE
feat: make video recording optional in play CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ To render an environment with a trained agent, use the enjoy command with the ru
 uv run pmarl enjoy "silly-camel-34"
 ```
 
+To save a recording, provide a path with `--video-path`:
+
+```bash
+uv run pmarl enjoy "silly-camel-34" --video-path my_run.mp4
+```
+
 To play as one of the agents:
 ```bash
 uv run pmarl enjoy "silly-camel-34" --human --pov
@@ -70,6 +76,8 @@ You can test out a environment without training a model using the `play` command
 ```
 uv run pmarl play ./config/return_baseline.json
 ```
+
+You can also record a video when testing by supplying `--video-path`.
 ---
 
 ## 🏋️‍♂️ Environments

--- a/jaxrl/cli.py
+++ b/jaxrl/cli.py
@@ -11,13 +11,31 @@ app = typer.Typer(pretty_exceptions_show_locals=False)
 
 
 @app.command()
-def enjoy(name: str, human: bool = False, pov: bool = False, seed: int = 0, selector: str | None = None):
-    play_from_run(name, human, pov, seed, selector)
+def enjoy(
+    name: str,
+    human: bool = False,
+    pov: bool = False,
+    seed: int = 0,
+    selector: str | None = None,
+    video_path: str | None = typer.Option(
+        None, help="Path to save video; if omitted, no video is recorded."
+    ),
+):
+    play_from_run(name, human, pov, seed, selector, video_path)
 
 
 @app.command()
-def play(name: str, human: bool = False, pov: bool = False, seed: int = 0, selector: str | None = None):
-    play_from_config(name, human, pov, seed, selector)
+def play(
+    name: str,
+    human: bool = False,
+    pov: bool = False,
+    seed: int = 0,
+    selector: str | None = None,
+    video_path: str | None = typer.Option(
+        None, help="Path to save video; if omitted, no video is recorded."
+    ),
+):
+    play_from_config(name, human, pov, seed, selector, video_path)
 
 
 @app.command("train")


### PR DESCRIPTION
## Summary
- allow `play` and `enjoy` commands to accept an optional `--video-path` argument
- only record frames and save video when a path is provided
- document the new flag in the README

## Testing
- `pytest --ignore=.venv` *(fails: ModuleNotFoundError: No module named 'jax')*
- `pip install jax typer` *(fails: Could not find a version that satisfies the requirement jax; No matching distribution found for typer)*

------
https://chatgpt.com/codex/tasks/task_e_68bee0200c4c833182a12b6d6b53becd