### PR TITLE
Add task id embedding and wrapper for multi-task training

### DIFF
--- a/config/multitask.json
+++ b/config/multitask.json
@@ -18,6 +18,7 @@
         "obs_type": "grid_flattened"
       },
       "hidden_features": 128,
+      "use_task_ids": true,
       "layer": {
         "feed_forward": {
           "glu": true,

--- a/jaxrl/config.py
+++ b/jaxrl/config.py
@@ -81,6 +81,7 @@ class TransformerActorCriticConfig(BaseModel):
         LinearObsEncoderConfig | GridCnnObsEncoderConfig | FlattenedObsEncoderConfig
     ) = Field(discriminator="obs_type")
     hidden_features: int
+    use_task_ids: bool = False
 
     layer: LayerConfig
     num_layers: int

--- a/jaxrl/envs/multitask.py
+++ b/jaxrl/envs/multitask.py
@@ -68,6 +68,10 @@ class MultiTaskWrapper(Environment):
     def num_agents(self) -> int:
         return sum([env.num_agents for env in self._envs])
 
+    @property
+    def num_tasks(self) -> int:
+        return len(self._envs)
+
     def create_placeholder_logs(self):
         return {
             name: env.create_placeholder_logs()

--- a/jaxrl/envs/task_id.py
+++ b/jaxrl/envs/task_id.py
@@ -1,0 +1,49 @@
+import jax
+from jax import numpy as jnp
+from functools import cached_property
+
+from jaxrl.envs.environment import Environment
+from jaxrl.envs.specs import ObservationSpec, ActionSpec
+from jaxrl.types import TimeStep
+
+
+class TaskIdWrapper(Environment):
+    """Environment wrapper that appends a constant task id to timesteps."""
+
+    def __init__(self, env: Environment, task_id: int):
+        self._env = env
+        self._task_id = jnp.asarray(task_id, dtype=jnp.int32)
+
+    def _add_task_id(self, timestep: TimeStep) -> TimeStep:
+        task_ids = jnp.full((self._env.num_agents,), self._task_id, dtype=jnp.int32)
+        return timestep._replace(task_id=task_ids)
+
+    def reset(self, rng_key: jax.Array):
+        state, timestep = self._env.reset(rng_key)
+        return state, self._add_task_id(timestep)
+
+    def step(self, state, action: jax.Array, rng_key: jax.Array):
+        state, timestep = self._env.step(state, action, rng_key)
+        return state, self._add_task_id(timestep)
+
+    @cached_property
+    def observation_spec(self) -> ObservationSpec:
+        return self._env.observation_spec
+
+    @cached_property
+    def action_spec(self) -> ActionSpec:
+        return self._env.action_spec
+
+    @property
+    def num_agents(self) -> int:
+        return self._env.num_agents
+
+    @property
+    def is_jittable(self) -> bool:
+        return self._env.is_jittable
+
+    def create_placeholder_logs(self):
+        return self._env.create_placeholder_logs()
+
+    def create_logs(self, state):
+        return self._env.create_logs(state)

--- a/jaxrl/model/rnn_bench.py
+++ b/jaxrl/model/rnn_bench.py
@@ -67,9 +67,9 @@ def main():
         config.learner.model,
         ObservationSpec(jnp.int8, obs_size, 7),
         4,
-        config.hl_gauss,
         seq_length,
         rngs=rngs,
+        task_vocab_size=None,
     )
 
     time = jnp.repeat(

--- a/jaxrl/play.py
+++ b/jaxrl/play.py
@@ -41,12 +41,18 @@ def get_action_from_keydown(event: pygame.event.Event | None):
 
 
 def load_policy(experiment: Experiment, env, max_steps, load: bool, rngs: nnx.Rngs):
+    task_vocab_size = (
+        getattr(env, "num_tasks", 1)
+        if experiment.config.learner.model.use_task_ids
+        else None
+    )
     model = TransformerActorCritic(
         experiment.config.learner.model,
         env.observation_spec,
         env.action_spec.num_actions,
         max_seq_length=max_steps,
         rngs=rngs,
+        task_vocab_size=task_vocab_size,
     )
 
     if load:

--- a/jaxrl/play_craftax.py
+++ b/jaxrl/play_craftax.py
@@ -32,13 +32,18 @@ def main(name: str, base_dir: str = "results", seed: int = 111):
 
     env = CraftaxEnvironment()
     rngs = nnx.Rngs(default=seed)
-
+    task_vocab_size = (
+        getattr(env, "num_tasks", 1)
+        if experiment.config.learner.model.use_task_ids
+        else None
+    )
     model = TransformerActorCritic(
         experiment.config.learner.model,
         env.observation_spec,
         env.action_spec.num_actions,
         max_seq_length=max_steps,
         rngs=rngs,
+        task_vocab_size=task_vocab_size,
     )
 
     with Checkpointer(experiment.checkpoints_url) as checkpointer:

--- a/jaxrl/rollout.py
+++ b/jaxrl/rollout.py
@@ -17,6 +17,7 @@ class RolloutState(NamedTuple):
     rewards: jax.Array
     terminated: jax.Array
     next_terminated: jax.Array
+    task_ids: jax.Array
 
     log_prob: jax.Array
     values: jax.Array
@@ -66,6 +67,9 @@ class Rollout:
             next_terminated=jnp.zeros(
                 (self.batch_size, self.trajectory_length), dtype=jnp.bool_
             ),
+            task_ids=jnp.zeros(
+                (self.batch_size, self.trajectory_length), dtype=index_type
+            ),
             log_prob=jnp.zeros(
                 (self.batch_size, self.trajectory_length), dtype=jnp.float32
             ),
@@ -110,6 +114,11 @@ class Rollout:
             terminated=state.terminated.at[:, step].set(timestep.terminated),
             next_terminated=state.next_terminated.at[:, step].set(
                 next_timestep.terminated
+            ),
+            task_ids=state.task_ids.at[:, step].set(
+                timestep.task_id
+                if timestep.task_id is not None
+                else jnp.zeros_like(state.task_ids[:, step])
             ),
             last_actions=state.last_actions.at[:, step].set(timestep.last_action),
             last_rewards=state.last_rewards.at[:, step].set(timestep.last_reward),

--- a/jaxrl/types.py
+++ b/jaxrl/types.py
@@ -24,3 +24,4 @@ class TimeStep(NamedTuple):
     last_reward: jax.Array
     # step_type: jax.Array
     action_mask: jax.Array | None  # (num_agents, num_actions)
+    task_id: jax.Array | None = None


### PR DESCRIPTION
## Summary
- support optional `task_id` in `TimeStep` and rollout storage
- introduce `TaskIdWrapper` and integrate in environment creation for multi-task setups
- add `use_task_ids` flag and derive task vocabulary size from number of wrapped tasks
- vectorize multi-task envs recursively and only add task embeddings when IDs are present

## Testing
- `python -m pip install --quiet jax jaxlib` (fails: Could not find a version that satisfies the requirement jax)
- `python -m pytest jaxrl/model/attention_test.py -q` (fails: ModuleNotFoundError: No module named 'jax')

------
https://chatgpt.com/codex/tasks/task_e_68bf05fb05d883318b9de3df23d38b8d