### PR TITLE
Make gridworld renderer window resizable

### DIFF
--- a/jaxrl/play.py
+++ b/jaxrl/play.py
@@ -130,6 +130,8 @@ def play(
     while time < 512 and running:
         did_step = False
         for event in pygame.event.get():
+            if client.handle_event(event):
+                continue
             if event.type == pygame.QUIT:
                 running = False
             if not running:


### PR DESCRIPTION
## Summary
- allow the gridworld renderer to rebuild tile scaling and offsets when the window changes size
- center the map with black margins when necessary while keeping translucent vision overlay aligned
- forward pygame resize events from the play loop to the renderer so the display surface and tiles update

## Testing
- python -m compileall jaxrl/envs/gridworld/renderer.py jaxrl/play.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a69ec028833199ef0eb49afa2d70