### PR TITLE
Rename create_env selector parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ uv run pmarl enjoy "silly-camel-34" --human --pov
 ```
 * `--human` means you control one of the agents with keyboard controls and `--pov` renders the environment from the agents point of view
 
-If the agent was trained on multiple environments you can select the right one using the `--selector` option. These correspond to the config.json
+If the agent was trained on multiple environments you can select the right one using the `--env` option. These correspond to the config.json
 ```bash
-uv run pmarl enjoy "silly-camel-34" --selector return40
+uv run pmarl enjoy "silly-camel-34" --env return40
 ```
 
 ### Test out an environment

--- a/jaxrl/benchmark.py
+++ b/jaxrl/benchmark.py
@@ -23,7 +23,7 @@ def benchmark(
     run_token: Optional[str],
     seed: int,
     vec_count: int,
-    selector: Optional[str],
+    env_name: Optional[str],
     steps: Optional[int],
     warmup: int,
     iters: int,
@@ -38,7 +38,10 @@ def benchmark(
 
     # Create environment
     env = create_env(
-        experiment.config.environment, max_steps, vec_count=vec_count, selector=selector
+        experiment.config.environment,
+        max_steps,
+        vec_count=vec_count,
+        env_name=env_name,
     )
 
     if not env.is_jittable:
@@ -108,7 +111,7 @@ def main(
         help="Existing experiment run token (loads config from results/).",
         rich_help_panel="Input",
     ),
-    selector: Optional[str] = typer.Option(
+    env: Optional[str] = typer.Option(
         None, help="Select a specific env when using a multi env config."
     ),
     seed: int = typer.Option(0, help="Random seed for RNGs and actions."),
@@ -124,7 +127,7 @@ def main(
     if (config is None) == (run is None):
         raise typer.BadParameter("Provide exactly one of --config or --run")
 
-    benchmark(config, run, seed, vec, selector, steps, warmup, iters)
+    benchmark(config, run, seed, vec, env_name=env, steps=steps, warmup=warmup, iters=iters)
 
 
 if __name__ == "__main__":

--- a/jaxrl/cli.py
+++ b/jaxrl/cli.py
@@ -18,12 +18,12 @@ def enjoy(
     human: bool = False,
     pov: bool = False,
     seed: int = 0,
-    selector: str | None = None,
+    env: str | None = None,
     video_path: str | None = typer.Option(
         None, help="Path to save video; if omitted, no video is recorded."
     ),
 ):
-    play_from_run(name, human, pov, seed, selector, video_path)
+    play_from_run(name, human, pov, seed, env_name=env, video_path=video_path)
 
 
 @app.command()
@@ -32,12 +32,12 @@ def play(
     human: bool = False,
     pov: bool = False,
     seed: int = 0,
-    selector: str | None = None,
+    env: str | None = None,
     video_path: str | None = typer.Option(
         None, help="Path to save video; if omitted, no video is recorded."
     ),
 ):
-    play_from_config(config, human, pov, seed, selector, video_path)
+    play_from_config(config, human, pov, seed, env_name=env, video_path=video_path)
 
 
 @app.command("train")

--- a/jaxrl/envs/env_config.py
+++ b/jaxrl/envs/env_config.py
@@ -62,13 +62,13 @@ def create_env(
     env_config: EnvironmentConfig | MultiTaskConfig,
     length: int,
     vec_count: int = 1,
-    selector: str | None = None,
+    env_name: str | None = None,
 ) -> Environment:
-    if env_config.env_type == "multi" and selector is not None:
+    if env_config.env_type == "multi" and env_name is not None:
         for env_def in env_config.envs:
-            if env_def.name == selector:
+            if env_def.name == env_name:
                 return create_env(env_def.env, length, vec_count=vec_count)
-        raise ValueError("Could not find environment for selector")
+        raise ValueError("Could not find environment matching env_name")
 
     match env_config.env_type:
         case "multi":

--- a/jaxrl/eval.py
+++ b/jaxrl/eval.py
@@ -138,7 +138,7 @@ def format_skill(rating: trueskill.Rating):
 
 def evaluate(
     run_token: str,
-    selector: Optional[str],
+    env_name: Optional[str],
     seed: int,
     steps: Optional[int],
     rounds: int,
@@ -148,7 +148,9 @@ def evaluate(
 
     max_steps = steps or experiment.config.max_env_steps
 
-    env = create_env(experiment.config.environment, max_steps, selector=selector)
+    env = create_env(
+        experiment.config.environment, max_steps, env_name=env_name
+    )
     rngs = nnx.Rngs(default=seed)
 
     models = load_policy(experiment, env, max_steps, rngs)
@@ -188,7 +190,7 @@ def main(
     run: str = typer.Option(
         ..., help="Existing experiment run token (under results/)", rich_help_panel="Input"
     ),
-    selector: Optional[str] = typer.Option(
+    env: Optional[str] = typer.Option(
         None, help="Select a specific env when using a multi env config."
     ),
     seed: int = typer.Option(0, help="Random seed for RNGs."),
@@ -198,7 +200,7 @@ def main(
     rounds: int = typer.Option(1000, help="Number of head-to-head rounds to run."),
     verbose: bool = typer.Option(False, help="Print per-round rating updates."),
 ):
-    evaluate(run, selector, seed, steps, rounds, verbose)
+    evaluate(run, env_name=env, seed=seed, steps=steps, rounds=rounds, verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/jaxrl/play.py
+++ b/jaxrl/play.py
@@ -61,11 +61,11 @@ def play_from_run(
     human_control: bool,
     pov: bool,
     seed: int,
-    selector: str | None = None,
+    env_name: str | None = None,
     video_path: str | None = None,
 ):
     experiment = Experiment.load(run_name, "results")
-    play(experiment, human_control, pov, seed, selector, True, video_path)
+    play(experiment, human_control, pov, seed, env_name, True, video_path)
 
 
 def play_from_config(
@@ -73,11 +73,11 @@ def play_from_config(
     human_control: bool,
     pov: bool,
     seed: int,
-    selector: str | None = None,
+    env_name: str | None = None,
     video_path: str | None = None,
 ):
     experiment = Experiment.from_config_file(config_name, "", create_directories=False)
-    play(experiment, human_control, pov, seed, selector, False, video_path)
+    play(experiment, human_control, pov, seed, env_name, False, video_path)
 
 
 def play(
@@ -85,13 +85,15 @@ def play(
     human_control: bool,
     pov: bool,
     seed: int,
-    selector: str | None = None,
+    env_name: str | None = None,
     load: bool = True,
     video_path: str | None = None,
 ):
     max_steps = experiment.config.max_env_steps
 
-    env = create_env(experiment.config.environment, max_steps, selector=selector)
+    env = create_env(
+        experiment.config.environment, max_steps, env_name=env_name
+    )
     rngs = nnx.Rngs(default=seed)
 
     model = load_policy(experiment, env, max_steps, load, rngs)


### PR DESCRIPTION
## Summary
- rename the optional argument in `create_env` from `selector` to `env_name`
- update the multi-environment selection logic and error message to use `env_name`
- adjust CLI helpers to pass the renamed keyword argument

## Testing
- not run (jax dependency unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca4099c66083319d398732fdc0fbc2