### PR TITLE
Add configurable checkpoint count

### DIFF
--- a/jaxrl/config.py
+++ b/jaxrl/config.py
@@ -152,6 +152,7 @@ class Config(BaseModel):
 
     updates_per_jit: int = 1
     update_steps: int
+    num_checkpoints: int = 50
 
     learner: LearnerConfig
     environment: EnvironmentConfig | MultiTaskConfig = Field(discriminator="env_type")


### PR DESCRIPTION
## Summary
- add a configurable `num_checkpoints` field to the training configuration
- derive the training checkpoint cadence from the new setting and guard against zero intervals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a7f166308331b81aa1a3827e9ea6