### PR TITLE
Update documentation and remove local mapox dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ uv sync --extra cuda
 
 Install hf cli: https://huggingface.co/docs/huggingface_hub/guides/cli
 ```bash
-hf download gabe00122/mapox --local-dir ./results
+hf download gabe00122/mapox-checkpoint --local-dir ./results
 ```
 
 This downloads `multitask`, a pretrained model that supports the following environments: `return`, `koth`, `prey`, and `scouts`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ https://github.com/user-attachments/assets/cf2a4c5b-37ce-4cc5-a63f-404277562152
 
 * Python 3.13+
 * [uv](https://github.com/astral-sh/uv) (a fast Python package installer and resolver)
+* [FFmpeg](https://ffmpeg.org/) (required for recording videos)
 
 ### Installation
 
@@ -50,7 +51,7 @@ This downloads `multitask`, a pretrained model that supports the following envir
 To render an environment with a trained agent, use the enjoy command with the run name.
 
 ```bash
-uv run pmarl enjoy multitask --seed 5 --env return --video-path ./videos/out.mp4
+uv run pmarl enjoy multitask --seed 5 --env return --video-path out.mp4
 ```
 
 ### Play an environment yourself

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ include = ["jaxrl*"]
 # ignore non-python top-level folders that confused the auto-discovery
 exclude = ["config*", "videos*"]
 
-[tool.uv.sources]
-mapox = { path = "../mapox" }
-
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",


### PR DESCRIPTION
## Summary
This PR updates the project documentation and removes the local development dependency on the mapox package, making the project more suitable for standard installation and usage.

## Key Changes
- **Dependencies**: Added FFmpeg as an explicit requirement in the README for video recording functionality
- **Model Download**: Updated the Hugging Face model repository reference from `gabe00122/mapox` to `gabe00122/mapox-checkpoint` to reflect the correct model checkpoint location
- **Video Output Path**: Simplified the example video output path from `./videos/out.mp4` to `out.mp4` for clarity
- **Build Configuration**: Removed the local path-based dependency on mapox from `pyproject.toml`, eliminating the development-only source configuration that was preventing standard package installation

## Details
The removal of the `[tool.uv.sources]` section in `pyproject.toml` indicates this project is transitioning from local development mode to a more standard distribution model where dependencies are resolved from package repositories rather than local paths.

https://claude.ai/code/session_01VTZdvpdNhGLEUwAZD4pmdN